### PR TITLE
adds --rm flag to delete container instance on exit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ build-regtest:
 	docker build --network=host -t dogecoind provision/dogecoind/
 
 regtest:
-	docker run --network=host -p 18444:18444 --name dogecoind_regtest dogecoind
+	docker run --rm --network=host -p 18444:18444 --name dogecoind_regtest dogecoind
 	
 restart:
 	docker start dogecoind_regtest


### PR DESCRIPTION
`make regtest` runs the container but without --rm container instance stays running after exit. should consider decoupling dogecoind -printtoconsole in Dockerfile if wanting to reuse existing shell while keeping container running imo.